### PR TITLE
feat: temporally switch off the qps comparison

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,6 +11,17 @@ from jina.helloworld.fashion.executors import MyEncoder, MyIndexer
 from jina.types.document.generators import from_ndarray
 
 
+os.environ['PATH'] += os.pathsep + resource_filename('jina', 'resources')
+os.environ['PATH'] += os.pathsep + resource_filename('jina', 'resources') + '/fashion/'
+
+for k, v in {'RESOURCE_DIR': resource_filename('jina', 'resources'),
+                'SHARDS': 4,
+                'PARALLEL': 4,
+                'REPLICAS': 4,
+                'HW_WORKDIR': 'workdir',
+                'WITH_LOGSERVER': False}.items():
+    os.environ[k] = str(v)
+
 err_msg = ''
 index_size = 60000
 query_size = 4096
@@ -20,17 +31,6 @@ query_time = -1
 
 def benchmark():
     try:
-        os.environ['PATH'] += os.pathsep + resource_filename('jina', 'resources')
-        os.environ['PATH'] += os.pathsep + resource_filename('jina', 'resources') + '/fashion/'
-
-        for k, v in {'RESOURCE_DIR': resource_filename('jina', 'resources'),
-                     'SHARDS': 4,
-                     'PARALLEL': 4,
-                     'REPLICAS': 4,
-                     'HW_WORKDIR': 'workdir',
-                     'WITH_LOGSERVER': False}.items():
-            os.environ[k] = str(v)
-
         f = Flow().add(uses=MyEncoder).add(uses=MyIndexer)
 
         with f:

--- a/app.py
+++ b/app.py
@@ -6,6 +6,13 @@ import time
 from packaging import version  # not built-in, need pip install
 
 
+err_msg = ''
+index_size = 60000
+query_size = 4096
+index_time = -1
+query_time = -1
+
+
 def benchmark():
     try:
         from jina import __version__, Flow
@@ -15,11 +22,6 @@ def benchmark():
 
         from pkg_resources import resource_filename
 
-        err_msg = ''
-        index_size = 60000
-        query_size = 4096
-        index_time = -1
-        query_time = -1
         
         os.environ['PATH'] += os.pathsep + resource_filename('jina', 'resources')
         os.environ['PATH'] += os.pathsep + resource_filename('jina', 'resources') + '/fashion/'

--- a/app.py
+++ b/app.py
@@ -1,9 +1,14 @@
-
 import json
 import os
 import time
 
 from packaging import version  # not built-in, need pip install
+from pkg_resources import resource_filename
+
+from jina import __version__, Flow
+from jina.helloworld.fashion.helper import load_mnist
+from jina.helloworld.fashion.executors import MyEncoder, MyIndexer
+from jina.types.document.generators import from_ndarray
 
 
 err_msg = ''
@@ -15,14 +20,6 @@ query_time = -1
 
 def benchmark():
     try:
-        from jina import __version__, Flow
-        from jina.helloworld.fashion.helper import load_mnist
-        from jina.helloworld.fashion.executors import MyEncoder, MyIndexer
-        from jina.types.document.generators import from_ndarray
-
-        from pkg_resources import resource_filename
-
-        
         os.environ['PATH'] += os.pathsep + resource_filename('jina', 'resources')
         os.environ['PATH'] += os.pathsep + resource_filename('jina', 'resources') + '/fashion/'
 
@@ -51,7 +48,7 @@ def benchmark():
             f.search(
                 data_query, 
                 shuffle=True,
-                request_size=1024, 
+                request_size=256, 
                 parameters={'top_k':50}
                 )
             query_time = time.perf_counter() - st

--- a/app.py
+++ b/app.py
@@ -22,14 +22,14 @@ for k, v in {'RESOURCE_DIR': resource_filename('jina', 'resources'),
                 'WITH_LOGSERVER': False}.items():
     os.environ[k] = str(v)
 
-err_msg = ''
-index_size = 60000
-query_size = 4096
-index_time = -1
-query_time = -1
-
 
 def benchmark():
+    err_msg = ''
+    index_size = 60000
+    query_size = 4096
+    index_time = -1
+    query_time = -1
+
     try:
         f = Flow().add(uses=MyEncoder).add(uses=MyIndexer)
 

--- a/ppstat.py
+++ b/ppstat.py
@@ -11,42 +11,50 @@ x.field_names = ['Version', 'Index QPS', 'Query QPS']
 index_qps = int(d[-1]['index_qps'])
 query_qps = int(d[-1]['query_qps'])
 x.add_row([f'current', index_qps, query_qps])
-for dd in d[:-1][::-1]:
-    x.add_row([f'[`{dd["version"]}`](https://github.com/jina-ai/jina/tree/v{dd["version"]})', int(dd['index_qps']), int(dd['query_qps'])])
 
-avg_index_qps = sum(dd['index_qps'] for dd in d[:-1]) / len(d[:-1])
-avg_query_qps = sum(dd['query_qps'] for dd in d[:-1]) / len(d[:-1])
+# temporally switch off the comparison
+# We have no docker image tagged as `2.0.0rc3`
+# We do not have convenient `from_ndarray` function in `2.0.0rc2`
+# We shall switch on the avg computation and comparison with `2.0.0rc7`
 
-delta_index = int((index_qps / avg_index_qps - 1) * 100)
-delta_query = int((query_qps / avg_query_qps - 1) * 100)
+# for dd in d[:-1][::-1]:
+#     x.add_row([f'[`{dd["version"]}`](https://github.com/jina-ai/jina/tree/v{dd["version"]})', int(dd['index_qps']), int(dd['query_qps'])])
 
-if delta_index > 10:
-    emoji_index = '🐎🐎🐎🐎'
-elif delta_index > 5:
-    emoji_index = '🐎🐎'
-elif delta_index < -5:
-    emoji_index = '🐢🐢'
-elif delta_index < -10:
-    emoji_index = '🐢🐢🐢🐢'
-else:
-    emoji_index = '😶'
+# avg_index_qps = sum(dd['index_qps'] for dd in d[:-1]) / len(d[:-1])
+# avg_query_qps = sum(dd['query_qps'] for dd in d[:-1]) / len(d[:-1])
 
-if delta_query > 10:
-    emoji_query = '🐎🐎🐎🐎'
-elif delta_query > 5:
-    emoji_query = '🐎🐎'
-elif delta_query < -5:
-    emoji_query = '🐢🐢'
-elif delta_query < -10:
-    emoji_query = '🐢🐢🐢🐢'
-else:
-    emoji_query = '😶'
+# delta_index = int((index_qps / avg_index_qps - 1) * 100)
+# delta_query = int((query_qps / avg_query_qps - 1) * 100)
+
+# if delta_index > 10:
+#     emoji_index = '🐎🐎🐎🐎'
+# elif delta_index > 5:
+#     emoji_index = '🐎🐎'
+# elif delta_index < -5:
+#     emoji_index = '🐢🐢'
+# elif delta_index < -10:
+#     emoji_index = '🐢🐢🐢🐢'
+# else:
+#     emoji_index = '😶'
+
+# if delta_query > 10:
+#     emoji_query = '🐎🐎🐎🐎'
+# elif delta_query > 5:
+#     emoji_query = '🐎🐎'
+# elif delta_query < -5:
+#     emoji_query = '🐢🐢'
+# elif delta_query < -10:
+#     emoji_query = '🐢🐢🐢🐢'
+# else:
+#     emoji_query = '😶'
 
 summary = f'## Latency summary\n ' \
           f'Current PR yields:\n' \
-          f'  - {emoji_index} **index QPS** at `{index_qps}`, delta to last 3 avg.: `{delta_index:+d}%`\n' \
-          f'  - {emoji_query} **query QPS** at `{query_qps}`, delta to last 3 avg.: `{delta_query:+d}%`\n\n' \
+          f'  - **index QPS** at `{index_qps}`\n' \
+          f'  - **query QPS** at `{query_qps}`\n\n' \
           f'## Breakdown'
+        #   f'  - {emoji_index} **index QPS** at `{index_qps}`, delta to last 3 avg.: `{delta_index:+d}%`\n' \
+        #   f'  - {emoji_query} **query QPS** at `{query_qps}`, delta to last 3 avg.: `{delta_query:+d}%`\n\n' \
 
 print(summary)
 x.set_style(MARKDOWN)


### PR DESCRIPTION
We have no docker image tagged as `2.0.0rc3`
We do not have a convenient `from_ndarray` function in `2.0.0rc2`
We shall switch on the avg computation and comparison with `2.0.0rc7`