### PR TITLE
fix: fixed indexer issue and added cleanup function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # output directory
 output/
 
+# indexer directory
+MyIndexer/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+comment.txt

--- a/ppstat.py
+++ b/ppstat.py
@@ -1,5 +1,5 @@
-import sys
 import json
+import sys
 
 from prettytable import MARKDOWN, PrettyTable
 
@@ -9,19 +9,23 @@ with open('output/stats.json') as fp:
     d = json.load(fp)
 
 x = PrettyTable()
-x.field_names = ['Version', 'Index QPS', 'Query QPS']
+x.field_names = ['Version', 'Index QPS', 'Query QPS', 'Import Time (s)']
 
 index_qps = int(d[-1]['index_qps'])
 query_qps = int(d[-1]['query_qps'])
-x.add_row([f'current', index_qps, query_qps])
+import_time = round(d[-1]['import_time'], 4)
+x.add_row([f'current', index_qps, query_qps, import_time])
 for dd in d[:-1][::-1]:
-    x.add_row([f'[`{dd["version"]}`](https://github.com/jina-ai/jina/tree/v{dd["version"]})', int(dd['index_qps']), int(dd['query_qps'])])
+    x.add_row([f'[`{dd["version"]}`](https://github.com/jina-ai/jina/tree/v{dd["version"]})',
+              int(dd['index_qps']), int(dd['query_qps']), round(dd['import_time'], 4)])
 
 avg_index_qps = sum(dd['index_qps'] for dd in d[:-1]) / len(d[:-1])
 avg_query_qps = sum(dd['query_qps'] for dd in d[:-1]) / len(d[:-1])
+avg_import_time = sum(dd['import_time'] for dd in d[:-1]) / len(d[:-1])
 
 delta_index = int((index_qps / avg_index_qps - 1) * 100)
 delta_query = int((query_qps / avg_query_qps - 1) * 100)
+delta_import_time = int((import_time / avg_import_time - 1) * 100)
 
 if delta_index > 10:
     emoji_index = '🐎🐎🐎🐎'
@@ -45,10 +49,22 @@ elif delta_query < -10:
 else:
     emoji_query = '😶'
 
+if delta_import_time > 10:
+    emoji_import_time = '🐎🐎🐎🐎'
+elif delta_import_time > 5:
+    emoji_import_time = '🐎🐎'
+elif delta_import_time < -5:
+    emoji_import_time = '🐢🐢'
+elif delta_import_time < -10:
+    emoji_import_time = '🐢🐢🐢🐢'
+else:
+    emoji_import_time = '😶'
+
 summary = f'## Latency summary\n ' \
           f'Current PR yields:\n' \
           f'  - {emoji_index} **index QPS** at `{index_qps}`, delta to last {num_last_release} avg.: `{delta_index:+d}%`\n' \
-          f'  - {emoji_query} **query QPS** at `{query_qps}`, delta to last {num_last_release} avg.: `{delta_query:+d}%`\n\n' \
+          f'  - {emoji_query} **query QPS** at `{query_qps}`, delta to last {num_last_release} avg.: `{delta_query:+d}%`\n' \
+          f'  - {emoji_import_time} `import jina` within **{import_time}s**, delta to last {num_last_release} avg.: `{delta_import_time:+d}%`\n\n' \
           f'## Breakdown'
 
 print(summary)


### PR DESCRIPTION
**Changes**:

- fixed indexer issues as suggested by @nan-wang 
- added some path check snippets
- refactored codes for future portability
- added import time benchmark

**Sample output**:

```json
[
  {
    "version": "2.0.3",
    "import_time": 0.083948083,
    "index_time": 22.019119375,
    "query_time": 72.660152917,
    "index_qps": 2724.904614855879,
    "query_qps": 56.372025595361436
  }
]
```

**Sample comment**:

## Latency summary
 Current PR yields:
  - 😶 **index QPS** at `2724`, delta to last 2.0.0 avg.: `+0%`
  - 😶 **query QPS** at `56`, delta to last 2.0.0 avg.: `+0%`
  - 😶 `import jina` within **0.0839s**, delta to last 2.0.0 avg.: `+0%`

## Breakdown
|                        Version                         | Index QPS | Query QPS | Import Time (s) |
|--------------------------------------------------------|-----------|-----------|-----------------|
|                        current                         |    2724   |     56    |      0.0839     |
| [`2.0.2`](https://github.com/jina-ai/jina/tree/v2.0.2) |    2724   |     56    |      0.0839     |
| [`2.0.3`](https://github.com/jina-ai/jina/tree/v2.0.3) |    2724   |     56    |      0.0839     |


Backed by [latency-tracking](https://github.com/jina-ai/latency-tracking). Further commits will update this comment.